### PR TITLE
Adds DerivingStrategies to EsqueletoSpec

### DIFF
--- a/test/EsqueletoSpec.hs
+++ b/test/EsqueletoSpec.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DerivingStrategies         #-}
 {-# LANGUAGE EmptyDataDecls             #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE FlexibleInstances          #-}


### PR DESCRIPTION
Currently, `persistent-typed-db`'s test suite fails to compile against `persistent-template` with the following error:
```
        Generating Persistent entities now requires the DerivingStrategies language extension. Please enable it by copy/pasting this line to the top of your file:
    
    {-# LANGUAGE DerivingStrategies #-}
       |
    24 | share [mkPersist (mkSqlSettingsFor ''TestDb)] [persistLowerCase|
       | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^...
```
Fortunately, the error message is so helpful the fix can be PR'd from GitHub's web UI 🎉 