### PR TITLE
Fix name conflicts for `Data.Aeson.Key` and `Database.Persist.Sql.Key`

### DIFF
--- a/src/Database/Persist/Typed.hs
+++ b/src/Database/Persist/Typed.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -40,7 +41,7 @@ import Control.Monad.IO.Class (MonadIO(..))
 import Control.Monad.Logger (NoLoggingT)
 import Control.Monad.Trans.Reader (ReaderT(..), ask, asks, withReaderT)
 import Control.Monad.Trans.Resource (MonadUnliftIO, ResourceT)
-import Data.Aeson as A
+import Data.Aeson qualified as A
 import Data.ByteString.Char8 (readInteger)
 import Data.Coerce (coerce)
 import Data.Conduit ((.|))

--- a/src/Database/Persist/Typed.hs
+++ b/src/Database/Persist/Typed.hs
@@ -40,7 +40,7 @@ import Control.Monad.IO.Class (MonadIO(..))
 import Control.Monad.Logger (NoLoggingT)
 import Control.Monad.Trans.Reader (ReaderT(..), ask, asks, withReaderT)
 import Control.Monad.Trans.Resource (MonadUnliftIO, ResourceT)
-import Data.Aeson qualified as A
+import qualified Data.Aeson as A
 import Data.ByteString.Char8 (readInteger)
 import Data.Coerce (coerce)
 import Data.Conduit ((.|))

--- a/src/Database/Persist/Typed.hs
+++ b/src/Database/Persist/Typed.hs
@@ -50,9 +50,8 @@ import qualified Data.Foldable as Foldable
 import Data.Foldable (toList)
 import Data.Int (Int64)
 import Data.List (find, inits, transpose)
-import qualified Data.List.NonEmpty as NEL
 import Data.Maybe (isJust)
-import Data.Monoid (mappend, (<>))
+import Data.Monoid (mappend)
 import Data.Pool (Pool)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -525,12 +524,12 @@ instance PersistUniqueWrite (SqlFor db) where
       conn <- ask
       let escape = connEscapeRawName conn
       let refCol n = Text.concat [escape (unEntityNameDB $ getEntityDBName t), ".", n]
-      let mkUpdateText = mkUpdateText' (escape . unFieldNameDB) refCol
+      let mkUpdateFieldText = mkUpdateText' (escape . unFieldNameDB) refCol
       case connUpsertSql conn of
         Just upsertSql -> case updates of
                             [] -> generalizeQuery $ defaultUpsertBy uniqueKey record updates
                             _:_ -> do
-                                let upds = Text.intercalate "," $ map mkUpdateText updates
+                                let upds = Text.intercalate "," $ map mkUpdateFieldText updates
                                     sql = upsertSql t (persistUniqueToFieldNames uniqueKey) upds
                                     vals = map toPersistValue (toPersistFields record)
                                         ++ map updatePersistValue updates

--- a/src/Database/Persist/Typed.hs
+++ b/src/Database/Persist/Typed.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}


### PR DESCRIPTION
When I compile this library with GHC 8.10.7, I notice a number of compiler errors of this form:

```
src/Database/Persist/Typed.hs:157:61: error:
    Ambiguous occurrence ‘Key’
    It could refer to
       either ‘A.Key’,
              imported from ‘Data.Aeson’ at src/Database/Persist/Typed.hs:43:1-22
              (and originally defined in ‘Data.Aeson.Key’)
           or ‘Database.Persist.Sql.Key’,
              imported from ‘Database.Persist.Sql’ at src/Database/Persist/Typed.hs:58:1-84
              (and originally defined in ‘Database.Persist.Class.PersistEntity’)
    |
157 | toSqlKeyFor :: (ToBackendKey (SqlFor a) record) => Int64 -> Key record
    | 
```

The first commit in this PR, namely, the addition of `qualified` to the import of `Data.Aeson`, prevents this error for me.

I also took the liberty of addressing a couple of compiler warnings.